### PR TITLE
Different color and symbol for root prompt for strug-theme

### DIFF
--- a/themes/strug.zsh-theme
+++ b/themes/strug.zsh-theme
@@ -4,8 +4,8 @@ export LSCOLORS=dxFxCxDxBxegedabagacad
 
 local git_branch='$(git_prompt_info)%{$reset_color%}$(git_remote_status)'
 
-PROMPT="%{$fg[green]%}╭─%n@%m %{$reset_color%}%{$fg[yellow]%}in %~ %{$reset_color%}${git_branch}
-%{$fg[green]%}╰\$ %{$reset_color%}"
+PROMPT="%{%(#~$fg[red]~$fg[green])%}╭─%n@%m %{$reset_color%}%{$fg[yellow]%}in %~ %{$reset_color%}${git_branch}
+%{%(#~$fg[red]~$fg[green])%}╰%(#~#~\$) %{$reset_color%}"
 
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[yellow]%}on "
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
@@ -22,4 +22,5 @@ ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE_COLOR=%{$fg[green]%}
 
 ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE=" -"
 ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE_COLOR=%{$fg[red]%}
+
 


### PR DESCRIPTION
My fork turns the color from green to red and uses a hashtag instead of the dollar sign for root prompt for strug-theme.